### PR TITLE
1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,31 +34,48 @@ var cornea = require("cornea")
 
 Creates a subclass. Useful for sharing common handlers.
 
-### `cornea#create(options)`
+### `cornea#create(options) > c`
 
 Creates a `cornea` view. Binds events.
 
-### `cornea#destroy`
+### `c.destroy`
 
 Unbinds the events.
 
-### `cornea#render`
+### `c.render(cb) > promise`
 
-Renders the given template into `view.element`.
+Renders the given template into `view.element` (asynchronous).
 
-### `cornea.binding(key)`
+### `c.binding(key)`
 
 Returns a `binding` object for the given `key`.
 
-### `cornea.data`
+### `c.getInitialData(fn)`
 
 Object for template data, bindings relate to it.
 
-### `cornea.update(key, value)`
+```javascript
+// sync
+cornea.extend({
+  getInitialData : function(){
+    return {
+      foo : "bar"
+    }
+  }
+})
+// async
+cornea.extend({
+  getInitialData : function(cb){
+    request.get("foo").then(cb)
+  }
+})
+```
 
-Updates bindings for `key` with `value`.
+### `c.update(object)`
 
-### `cornea.setStyle(selector, properties)`
+Updates data with the keys and values in object.
+
+### `c.setStyle(selector, properties)`
 
 Sets the style for the given `selector` with the properties.
 
@@ -66,8 +83,9 @@ Sets the style for the given `selector` with the properties.
 
 Passing `null` as a value resets the property to its defaults.
 
-**NOTE** : careful, styles are not scoped, selectors affect all the elements
-in the DOM.
+Styles are scoped to the view.
+
+---
 
 ### `binding`
 
@@ -94,6 +112,8 @@ Options are :
 
 * `bindingOptions.escape`
 * `bindingOptions.template`
+
+---
 
 ### `options`
 
@@ -138,6 +158,8 @@ List of events to bind.
 **note** : if `view.listener` changes, it will affect the event callback
 (a hook is set and fetches the right method)
 
+---
+
 ## class-events
 
 **NOTE** : These are `cornea` events, not DOM ones.
@@ -175,6 +197,11 @@ module.exports = cornea.extend({
       lightbox.show()
     })
   },
+  getInitialData : function(cb){
+    request
+      .get("i18n/lighbox")
+      .then(cb)
+  },
   events : [
     {
       type : "click",
@@ -187,11 +214,11 @@ module.exports = cornea.extend({
   },
   show : function(left, top){
     this.element.classList.add("Lightbox--visible")
-    this.setStyle(".Lightbox", {
+    this.setStyle(".Lightbox-lightbox", {
       "top" : top + "px",
       "left" : left + "px"
     })
-    this.fire("lightbox:show")
+    this.emit("lightbox:show")
   },
   template : function(data){
     return [
@@ -205,9 +232,6 @@ module.exports = cornea.extend({
           }),
       "</div>"
     ].join("")
-  },
-  data : {
-    value : ""
   }
 })
 ```
@@ -219,9 +243,14 @@ var view = require("./myView")
   , otherView = require("./otherView").create()
 
 var myView = view.create()
-
-myView.update("value", "oh hai")
-myView.listen("lightbox:show", function(){
-  otherView.hide()
-})
+myView
+  .render()
+  .then(function(){
+    myView.update({
+      value : "oh hai"
+    })
+    myView.on("lightbox:show", function(){
+      otherView.hide()
+    })
+  })
 ```

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ List of events to bind.
 **NOTE** : These are `cornea` events, not DOM ones.
 This is mainly app communication.
 
-### `cornea.listen(type, listener)`
+### `cornea.on(type, listener)`
 
 listens the the `type` event and attaches `listener` to it.
 
-### `cornea.stopListening([type[, listener]])`
+### `cornea.off([type[, listener]])`
 
 stops listening :
 
@@ -155,11 +155,7 @@ stops listening :
 - if `type` is set : all `type` events
 - if `type` and `listener` are set : the `listener` for this `type`
 
-### `cornea.fire(type[, data…])`
-
-fires asynchronously the given `type` event, passing the `data…` arguments to the listeners.
-
-### `cornea.fireSync(type[, data])`
+### `cornea.emit(type[, data…])`
 
 fires synchronously the given `type` event, passing the `data…` arguments to the listeners.
 

--- a/binding/index.js
+++ b/binding/index.js
@@ -21,7 +21,7 @@ module.exports = klass.extend({
 
   toNode : function(options){
     if(options == void 0) options = {}
-    var node = document.createElement(options.nodeName || "div")
+    var node = document.createElement(options.nodeName || "span")
       , escape = options.hasOwnProperty("escape") ? options.escape : true
       , tmpl
     node.className =

--- a/binding/index.js
+++ b/binding/index.js
@@ -1,6 +1,6 @@
 var klass = require("bloody-class")
-  , template = require("../template")
-  , attribute = require("./attribute")
+var template = require("../template")
+var attribute = require("./attribute")
 
 module.exports = klass.extend({
 
@@ -20,10 +20,12 @@ module.exports = klass.extend({
   },
 
   toNode : function(options){
-    if(options == void 0) options = {}
+    if(options == void 0) {
+      options = {}
+    }
     var node = document.createElement(options.nodeName || "span")
-      , escape = options.hasOwnProperty("escape") ? options.escape : true
-      , tmpl
+    var escape = options.hasOwnProperty("escape") ? options.escape : true
+    var tmpl
     node.className =
       this.CLASSNAME_BINDING +
       (options.className ? " " + options.className : "")
@@ -38,21 +40,29 @@ module.exports = klass.extend({
 
     node.setAttribute(this.ATTRIBUTE_BINDING, "innerHTML")
     node.setAttribute(this.ATTRIBUTE_KEY, this.key)
-    node.setAttribute(this.ATTRIBUTE_TEMPLATE, tmpl = options.template || "#{*}")
-    if(escape) node.setAttribute(this.ATTRIBUTE_ESCAPE, "")
+    tmpl = options.template || "#{*}"
+    node.setAttribute(this.ATTRIBUTE_TEMPLATE, tmpl)
+    if(escape) {
+      node.setAttribute(this.ATTRIBUTE_ESCAPE, "")
+    }
     attribute.set(node, "innerHTML", template(tmpl, this.view.data && this.view.data[this.key], escape))
     return node
   },
 
   bindAttribute : function(node, attributeName, options){
-    if(options == void 0) options = {}
+    if(options == void 0) {
+      options = {}
+    }
     var escape = options.hasOwnProperty("escape") ? options.escape : true
-      , tmpl
+    var tmpl
     node.setAttribute(this.ATTRIBUTE_BINDING, attributeName)
     node.setAttribute(this.ATTRIBUTE_KEY, this.key)
-    node.setAttribute(this.ATTRIBUTE_TEMPLATE, tmpl = options.template || "#{*}")
+    tmpl = options.template || "#{*}"
+    node.setAttribute(this.ATTRIBUTE_TEMPLATE, tmpl)
     node.className = (node.className + " " + this.CLASSNAME_BINDING).trim()
-    if(escape) node.setAttribute(this.ATTRIBUTE_ESCAPE, "")
+    if(escape) {
+      node.setAttribute(this.ATTRIBUTE_ESCAPE, "")
+    }
     attribute.set(node, attributeName, template(tmpl, this.view.data && this.view.data[this.key], escape))
   }
 })

--- a/events/index.js
+++ b/events/index.js
@@ -2,11 +2,15 @@ var createListener = require("./createListener")
 
 module.exports = {
   listen : function(view){
-    if(!view.events) return
+    if(!view.events) {
+      return
+    }
     view.events.forEach(listen, view)
   },
   stopListening : function(view){
-    if(!view.events) return
+    if(!view.events) {
+      return
+    }
     view.events.forEach(stopListening, view)
   }
 }

--- a/events/matches.js
+++ b/events/matches.js
@@ -1,29 +1,29 @@
 var docEl = document.documentElement
-  , nativeMatchesSelector =
-      docEl.matches ||
-      docEl.matchesSelector ||
-      docEl.webkitMatchesSelector ||
-      docEl.mozMatchesSelector ||
-      docEl.oMatchesSelector ||
-      docEl.msMatchesSelector ||
-      function(selector) {
-        var element = this
-        var parent = element.parentNode
-        var match
-        var index = -1
-        var length
-        if(!parent) {
-          return false
-        }
-        match = parent.querySelectorAll(selector)
-        length = match.length
-        while(++index < length) {
-          if(match[index] == element) {
-            return true
-          }
-        }
-        return false
+var nativeMatchesSelector =
+  docEl.matches ||
+  docEl.matchesSelector ||
+  docEl.webkitMatchesSelector ||
+  docEl.mozMatchesSelector ||
+  docEl.oMatchesSelector ||
+  docEl.msMatchesSelector ||
+  function(selector) {
+    var element = this
+    var parent = element.parentNode
+    var match
+    var index = -1
+    var length
+    if(!parent) {
+      return false
+    }
+    match = parent.querySelectorAll(selector)
+    length = match.length
+    while(++index < length) {
+      if(match[index] == element) {
+        return true
       }
+    }
+    return false
+  }
 
 if(!nativeMatchesSelector) {
   throw new Error("this browser does not support .matchesSelector")
@@ -37,8 +37,12 @@ module.exports = function(rootNode, node, selector){
     return node
   }
   while(node = node.parentNode) {
-    if(node == rootNode) break
-    if(node.nodeType != node.ELEMENT_NODE) break
+    if(node == rootNode) {
+      break
+    }
+    if(node.nodeType != node.ELEMENT_NODE) {
+      break
+    }
     if(nativeMatchesSelector.call(node, selector)) {
       return node
     }

--- a/index.js
+++ b/index.js
@@ -108,8 +108,14 @@ module.exports = eventClass.extend({
   },
 
   updateBindings : function(){
-    this.bindings =
-      [].slice.call(this.element.querySelectorAll("." + binding.CLASSNAME_BINDING))
+    var index = -1
+    var bindings = this.element.querySelectorAll("." + binding.CLASSNAME_BINDING)
+    var length = bindings.length
+    var array = Array(length)
+    while(++index < length) {
+      array[index] = bindings[index]
+    }
+    this.bindings = array
   },
 
   update : function(object){

--- a/index.js
+++ b/index.js
@@ -7,12 +7,16 @@ var eventClass = require("bloody-events")
   , extend = require("./utils/extend")
   , empty = function(){return ""}
   , _forEach = [].forEach
+  , asap = require("asap")
+  , promise = require("bloody-promise")
+  , uniq = -1
 
 module.exports = eventClass.extend({
 
   _styles: null,
 
   constructor : function(object){
+    var view = this
     eventClass.constructor.call(this)
     extend(this, object)
     if(typeof this.element == "string") {
@@ -24,10 +28,33 @@ module.exports = eventClass.extend({
     if(!this.element) {
       this.element = document.createElement("div")
     }
+    if(!this.element.hasAttribute("data-cornea-id")) {
+      this.element.setAttribute("data-cornea-id", ++uniq)
+    }
+    this.id = this.element.getAttribute("data-cornea-id")
     if(typeof this.initialize == "function") {
       this.initialize.apply(this, arguments)
     }
     this.initEvents()
+    if(typeof this.getInitialData == "function") {
+      this._data = promise.create(function(resolve){
+        var value = view.getInitialData(resolve)
+        if(value != null) {
+          resolve(value)
+        }
+      })
+    } else {
+      this._data = promise.create(function(resolve){
+        resolve({})
+      })
+    }
+    this._data.then(function(value){
+      view.data = value
+      view.emit("dataReceived", value)
+    })
+    asap(function(){
+      view.emit("create")
+    })
   },
 
   destructor : function(){
@@ -38,6 +65,7 @@ module.exports = eventClass.extend({
     if(this._styles != null) {
       this._styles.destroy()
     }
+    this.emit("destroy")
   },
 
   initEvents : function(){
@@ -54,18 +82,28 @@ module.exports = eventClass.extend({
 
   template : empty,
 
-  render : function(){
-    var contents = this.template(this.data)
-    this.element.innerHTML = ""
-    if(typeof contents == "string") {
-      this.element.innerHTML = contents
-      return this.updateBindings()
-    }
-    if(contents && contents.nodeType) {
-      this.element.innerHTML = ""
-      this.element.appendChild(contents)
-      this.updateBindings()
-    }
+  render : function(cb){
+    var view = this
+    var then = this._data.then(function(){
+      view.emit("beforeRender")
+      var contents = view.template(view.data)
+      view.element.innerHTML = ""
+      if(typeof contents == "string") {
+        view.element.innerHTML = contents
+        view.updateBindings()
+        return
+      }
+      if(contents && contents.nodeType) {
+        view.element.innerHTML = ""
+        view.element.appendChild(contents)
+        view.updateBindings()
+      }
+    })
+    then.then(function(){
+      view.emit("afterRender")
+    })
+    then.then(cb)
+    return then
   },
 
   updateBindings : function(){
@@ -73,27 +111,38 @@ module.exports = eventClass.extend({
       this.element.querySelectorAll("." + binding.CLASSNAME_BINDING)
   },
 
-  update : function(key, value){
-    if(this.data != null) {
-      this.data[key] = value
+  update : function(object){
+    var key
+    var value
+    if(object == null || typeof object != "object") {
+      return
     }
-    _forEach.call(this.bindings, function(element){
-      var property, templateString, content
-      if(element.getAttribute(binding.ATTRIBUTE_KEY) != key) {
-        return
+    this.emit("beforeUpdate")
+    for(key in object) {
+      value = object[key]
+      if(this.data != null) {
+        this.data[key] = value
       }
-      property = element.getAttribute(binding.ATTRIBUTE_BINDING)
-      templateString = element.getAttribute(binding.ATTRIBUTE_TEMPLATE)
-      content = template(templateString, value, element.hasAttribute(binding.ATTRIBUTE_ESCAPE))
-      attribute.set(element, property, content)
-    })
+      _forEach.call(this.bindings, function(element){
+        var property, templateString, content
+        if(element.getAttribute(binding.ATTRIBUTE_KEY) != key) {
+          return
+        }
+        property = element.getAttribute(binding.ATTRIBUTE_BINDING)
+        templateString = element.getAttribute(binding.ATTRIBUTE_TEMPLATE)
+        content = template(templateString, value, element.hasAttribute(binding.ATTRIBUTE_ESCAPE))
+        attribute.set(element, property, content)
+      })
+    }
+    this.emit("afterUpdate")
   },
 
   setStyle : function(selectorText, properties){
     if(this._styles == null) {
-      this._styles = styles.create()
+      this._styles = styles.create(this)
     }
     this._styles.setStyle(selectorText, properties)
+    this.emit("styleChange")
   }
 
 })

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 var eventClass = require("bloody-events")
-  , events = require("./events")
-  , binding = require("./binding")
-  , attribute = require("./binding/attribute")
-  , styles = require("./styles")
-  , template = require("./template")
-  , extend = require("./utils/extend")
-  , empty = function(){return ""}
-  , _forEach = [].forEach
-  , asap = require("asap")
-  , promise = require("bloody-promise")
-  , uniq = -1
+var events = require("./events")
+var binding = require("./binding")
+var attribute = require("./binding/attribute")
+var styles = require("./styles")
+var template = require("./template")
+var extend = require("./utils/extend")
+var empty = function(){return ""}
+var _forEach = [].forEach
+var asap = require("asap")
+var promise = require("bloody-promise")
+var uniq = -1
 
 module.exports = eventClass.extend({
 

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = eventClass.extend({
 
   updateBindings : function(){
     this.bindings =
-      this.element.querySelectorAll("." + binding.CLASSNAME_BINDING)
+      [].slice.call(this.element.querySelectorAll("." + binding.CLASSNAME_BINDING))
   },
 
   update : function(object){

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = eventClass.extend({
     if(!this.element) {
       this.element = document.createElement("div")
     }
+    this.bindings = []
     if(!this.element.hasAttribute("data-cornea-id")) {
       this.element.setAttribute("data-cornea-id", ++uniq)
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bloody-class": "^1.2.1",
-    "bloody-events": "^0.2.2"
+    "bloody-events": "^1.0.0"
   },
   "testling": {
     "files": "test/**.js",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
   },
   "homepage": "https://github.com/bloodyowl/cornea",
   "devDependencies": {
+    "bloody-promise": "^1.0.0",
     "tape": "^2.5.0",
     "testling": "^1.6.1"
   },
   "dependencies": {
+    "asap": "^1.0.0",
     "bloody-class": "^1.2.1",
-    "bloody-events": "^1.0.0"
+    "bloody-events": "^1.0.0",
+    "bloody-promise": "^1.0.0"
   },
   "testling": {
     "files": "test/**.js",

--- a/styles/index.js
+++ b/styles/index.js
@@ -3,9 +3,10 @@ var klass = require("bloody-class")
   , hasOwnProperty = Object.prototype.hasOwnProperty
 
 module.exports = klass.extend({
-  constructor : function(){
+  constructor : function(view){
     this.element = document.createElement("style")
     head.appendChild(this.element)
+    this.view = view
     this._selectors = {}
   },
   destructor : function(){
@@ -14,12 +15,20 @@ module.exports = klass.extend({
     }
     this.element = null
   },
+  _createSelector : function(selector){
+    var scope = [
+      "[data-cornea-id=\"",
+        this.view.id,
+      "\"] "
+    ].join("")
+    return scope + selector.split(",").join(", " + scope)
+  },
   createRule : function(selectorText){
     var index = this.element.sheet.cssRules.length
       , selector = selectorText.trim()
     this._selectors[selector] = index
     this.element.sheet.insertRule(
-      selector + " {}",
+      this._createSelector(selector) + " {}",
       index
     )
     return this.element.sheet.cssRules[index]

--- a/styles/index.js
+++ b/styles/index.js
@@ -1,6 +1,6 @@
 var klass = require("bloody-class")
-  , head = document.head || document.getElementsByTagName("head")[0]
-  , hasOwnProperty = Object.prototype.hasOwnProperty
+var head = document.head || document.getElementsByTagName("head")[0]
+var hasOwnProperty = Object.prototype.hasOwnProperty
 
 module.exports = klass.extend({
   constructor : function(view){
@@ -25,7 +25,7 @@ module.exports = klass.extend({
   },
   createRule : function(selectorText){
     var index = this.element.sheet.cssRules.length
-      , selector = selectorText.trim()
+    var selector = selectorText.trim()
     this._selectors[selector] = index
     this.element.sheet.insertRule(
       this._createSelector(selector) + " {}",
@@ -35,7 +35,7 @@ module.exports = klass.extend({
   },
   getRule : function(selectorText){
     var selector = selectorText.trim()
-      , index = this._selectors[selector]
+    var index = this._selectors[selector]
     if(index == null) {
       return null
     }
@@ -43,7 +43,8 @@ module.exports = klass.extend({
   },
   setStyle : function(selectorText, properties){
     var rule = this.getRule(selectorText)
-      , key, property
+    var key
+    var property
     if(rule == null) {
       rule = this.createRule(selectorText)
     }

--- a/template/escape.js
+++ b/template/escape.js
@@ -1,12 +1,12 @@
 var htmlChars = {
-      "&": "&amp;",
-      "<": "&lt;",
-      ">": "&gt;",
-      "'": "&quot;",
-      "\"": "&#39;"
-    }
-  , keys = Object.keys(htmlChars)
-  , regExp = RegExp("[" + keys.join("") + "]", "g")
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "'": "&quot;",
+  "\"": "&#39;"
+}
+var keys = Object.keys(htmlChars)
+var regExp = RegExp("[" + keys.join("") + "]", "g")
 
 function escapeHTML(match) {
   return htmlChars[match]

--- a/template/index.js
+++ b/template/index.js
@@ -1,5 +1,5 @@
 var escape = require("./escape")
-  , templateRE = /#\{\*\}/g
+var templateRE = /#\{\*\}/g
 
 module.exports = function(template, data, shouldEscape){
   if(data == null) {

--- a/test/binding.js
+++ b/test/binding.js
@@ -1,11 +1,12 @@
 var tape = require("tape")
-  , binding = require("../binding")
-  , view = {data:{foo:"test"}}
+var binding = require("../binding")
+var view = {data:{foo:"test"}}
+
 tape("binding.toString", function(test){
 
   var b = binding.create(view, "foo")
-    , b1 = b.toString()
-    , b2 = b.toString({nodeName:"span"})
+  var b1 = b.toString()
+  var b2 = b.toString({nodeName:"span"})
 
   test.notEqual(b1.indexOf("class=\"cornea-binding\""), -1)
   test.notEqual(b1.indexOf("data-cornea-binding=\"innerHTML\""), -1)
@@ -22,7 +23,7 @@ tape("binding.toString", function(test){
 tape("binding.toNode", function(test){
 
   var b = binding.create(view, "foo")
-    , b1 = b.toNode()
+  var b1 = b.toNode()
 
   test.equal(b1.nodeName, "SPAN", "gets default nodeName")
   test.equal(b1.className, "cornea-binding", "sets className")
@@ -38,13 +39,13 @@ tape("binding.toNode", function(test){
 tape("binding.toNode (extend)", function(test){
 
   var b = binding.create(view, "foo")
-    , b1 = b.toNode({
-        nodeName:"span",
-        attributes:{"data-foo":"bar"},
-        className:"foo bar",
-        template:"it is #{*}",
-        escape:false
-      })
+  var b1 = b.toNode({
+    nodeName:"span",
+    attributes:{"data-foo":"bar"},
+    className:"foo bar",
+    template:"it is #{*}",
+    escape:false
+  })
 
   test.equal(b1.nodeName, "SPAN", "gets default nodeName")
   test.equal(b1.className, "cornea-binding foo bar", "sets className with custom ones")
@@ -61,7 +62,7 @@ tape("binding.toNode (extend)", function(test){
 tape("binding.bindAttribute", function(test){
 
   var b = binding.create(view, "foo")
-    , node = document.createElement("div")
+  var node = document.createElement("div")
 
   b.bindAttribute(node, "data-value")
   test.equal(node.className, "cornea-binding", "sets className")
@@ -77,7 +78,7 @@ tape("binding.bindAttribute", function(test){
 tape("binding.bindAttribute (extend)", function(test){
 
   var b = binding.create(view, "foo")
-    , node = document.createElement("div")
+  var node = document.createElement("div")
 
   b.bindAttribute(node, "data-value", {template:"foo #{*}", escape:false})
   test.equal(node.className, "cornea-binding", "sets className")

--- a/test/binding.js
+++ b/test/binding.js
@@ -2,7 +2,7 @@ var tape = require("tape")
   , binding = require("../binding")
   , view = {data:{foo:"test"}}
 tape("binding.toString", function(test){
-  
+
   var b = binding.create(view, "foo")
     , b1 = b.toString()
     , b2 = b.toString({nodeName:"span"})

--- a/test/binding.js
+++ b/test/binding.js
@@ -12,11 +12,11 @@ tape("binding.toString", function(test){
   test.notEqual(b1.indexOf("data-cornea-key=\"foo\""), -1)
   test.notEqual(b1.indexOf("data-cornea-template=\"#{*}\""), -1)
   test.notEqual(b1.indexOf("data-cornea-escape"), -1)
-  test.notEqual(b1.indexOf("div"), -1)
   test.notEqual(b2.indexOf("span"), -1)
+  test.notEqual(b2.indexOf("span", b2.indexOf("span")), -1)
   test.notEqual(b2.indexOf("test"), -1)
   test.end()
-  
+
 })
 
 tape("binding.toNode", function(test){
@@ -24,7 +24,7 @@ tape("binding.toNode", function(test){
   var b = binding.create(view, "foo")
     , b1 = b.toNode()
 
-  test.equal(b1.nodeName, "DIV", "gets default nodeName")
+  test.equal(b1.nodeName, "SPAN", "gets default nodeName")
   test.equal(b1.className, "cornea-binding", "sets className")
   test.equal(b1.getAttribute("data-cornea-binding"), "innerHTML", "sets binding")
   test.equal(b1.getAttribute("data-cornea-key"), "foo", "sets key")

--- a/test/createListener.js
+++ b/test/createListener.js
@@ -1,47 +1,47 @@
 var tape = require("tape")
-  , createListener = require("../events/createListener")
+var createListener = require("../events/createListener")
 
 tape("createListener (no selector)", function(test){
-  
+
   var fakeEventObject = {}
-    , fakeView = {
-        foo : function(eventObject, target){
-          test.equal(fakeView, this, "passes view as thisValue")
-          test.equal(target, document.body, "passes rootNode as target")
-          test.equal(eventObject, fakeEventObject, "passes eventObject")
-        }
-      }
-    , div = document.createElement("div")
-    , span = document.createElement("span")
-    , listener
-  
+  var fakeView = {
+    foo : function(eventObject, target){
+      test.equal(fakeView, this, "passes view as thisValue")
+      test.equal(target, document.body, "passes rootNode as target")
+      test.equal(eventObject, fakeEventObject, "passes eventObject")
+    }
+  }
+  var div = document.createElement("div")
+  var span = document.createElement("span")
+  var listener
+
   div.className = "testClass-div--listener"
   span.className = "testClass-span--listener"
-  
+
   div.appendChild(span)
   document.body.appendChild(div)
-  
+
   listener = createListener.call(fakeView, document.body, null, "foo")
   listener(fakeEventObject)
   test.end()
-  
+
 })
 
 tape("createListener (selector)", function(test){
 
   var div = document.createElement("div")
-    , span = document.createElement("span")
-    , fakeEventObject = {
-        target : span
-      }
-    , fakeView = {
-        foo : function(eventObject, target){
-          test.equal(fakeView, this, "passes view as thisValue")
-          test.equal(target, div, "passes target")
-          test.equal(eventObject, fakeEventObject, "passes eventObject")
-        }
-      }
-    , listener
+  var span = document.createElement("span")
+  var fakeEventObject = {
+    target : span
+  }
+  var fakeView = {
+    foo : function(eventObject, target){
+      test.equal(fakeView, this, "passes view as thisValue")
+      test.equal(target, div, "passes target")
+      test.equal(eventObject, fakeEventObject, "passes eventObject")
+    }
+  }
+  var listener
 
   div.className = "testClass-div--listener"
   span.className = "testClass-span--listener"

--- a/test/escape.js
+++ b/test/escape.js
@@ -1,10 +1,10 @@
 var tape = require("tape")
-  , esc = require("../template/escape")
+var esc = require("../template/escape")
 
 tape("escape", function(test){
 
   var escaped = esc("<div class='foo' id=\"bar\">&</div>")
-    , expected = "&lt;div class=&quot;foo&quot; id=&#39;bar&#39;&gt;&amp;&lt;/div&gt;"
+  var expected = "&lt;div class=&quot;foo&quot; id=&#39;bar&#39;&gt;&amp;&lt;/div&gt;"
 
   test.equal(escaped, expected)
   test.equal(esc(1), "1", "accepts numbers")

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,49 @@
+var tape = require("tape")
+var cornea = require("..")
+
+tape("hooks create", function(test){
+  cornea
+    .create()
+    .on("create", function(){
+      test.pass("create")
+      test.end()
+    })
+})
+
+tape("hooks render", function(test){
+  var view = cornea.create()
+  var index = -1
+  view.on("beforeRender", function(){
+    test.equal(++index, 0)
+  })
+  view.on("afterRender", function(){
+    test.equal(++index, 1)
+    test.end()
+  })
+  view.render()
+})
+
+tape("hooks update", function(test){
+  var view = cornea.create()
+  var index = -1
+  view.on("beforeUpdate", function(){
+    test.equal(++index, 0)
+  })
+  view.on("afterUpdate", function(){
+    test.equal(++index, 1)
+    test.end()
+  })
+  view.update({
+    foo : "bar"
+  })
+})
+
+tape("hooks style", function(test){
+  var view = cornea.create()
+  var index = -1
+  view.on("styleChange", function(){
+    test.equal(++index, 0)
+    test.end()
+  })
+  view.setStyle(".foo", {opacity: 0})
+})

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -45,5 +45,5 @@ tape("hooks style", function(test){
     test.equal(++index, 0)
     test.end()
   })
-  view.setStyle(".foo", {opacity: 0})
+  view.setStyle(".foo", {opacity: "0"})
 })

--- a/test/matches.js
+++ b/test/matches.js
@@ -1,16 +1,16 @@
 var tape = require("tape")
-  , matches = require("../events/matches")
+var matches = require("../events/matches")
 
 tape("matches", function(test){
   var div = document.createElement("div")
-    , span = document.createElement("span")
-    , i = document.createElement("i")
+  var span = document.createElement("span")
+  var i = document.createElement("i")
 
   div.appendChild(span)
   div.className = "testClass--div"
   document.body.className += " testClass"
   document.body.appendChild(div)
-  
+
   test.equal(matches(document.body, div, ".testClass--div"), div, "matches div correctly")
   test.equal(matches(document.body, div, ".foobar"), false, "returns false if doesn't match")
   test.equal(matches(document.body, span, ".testClass--div"), div, "bubbles up to the right element")

--- a/test/render.js
+++ b/test/render.js
@@ -15,22 +15,25 @@ tape("render", function(test){
         }
       })
 
-  view.render()
-
-  test.equal(view.bindings.length, 1)
-  test.equal(view.bindings[0].nodeName, "SPAN")
-  view.update("foo", "bar")
-  test.equal(view.bindings[0].innerHTML, "bar")
-  test.end()
-
+  view.render(function(){
+    test.equal(view.bindings.length, 1)
+    test.equal(view.bindings[0].nodeName, "SPAN")
+    view.update({
+      foo : "bar"
+    })
+    test.equal(view.bindings[0].innerHTML, "bar")
+    test.end()
+  })
 })
 
 
 tape("render (escaped)", function(test){
 
   var view = cornea.create({
-        data : {
-          "foo" : "<div>"
+        getInitialData : function(){
+          return {
+            "foo" : "<div>"
+          }
         },
         template : function(){
           return [
@@ -46,15 +49,18 @@ tape("render (escaped)", function(test){
       })
     , el
 
-  view.render()
-  el = view.element.querySelector(".test")
+  view.render(function(){
+    el = view.element.querySelector(".test")
 
-  test.equal(el.innerHTML, "&lt;div&gt;")
-  view.update("foo", "<span>")
-  test.equal(view.data.foo, "<span>")
-  test.equal(view.element.querySelector(".test"), el, "same element")
-  test.equal(el.innerHTML, "&lt;span&gt;")
-  test.end()
+    test.equal(el.innerHTML, "&lt;div&gt;")
+    view.update({
+      foo : "<span>"
+    })
+    test.equal(view.data.foo, "<span>")
+    test.equal(view.element.querySelector(".test"), el, "same element")
+    test.equal(el.innerHTML, "&lt;span&gt;")
+    test.end()
+  })
 
 })
 
@@ -62,8 +68,10 @@ tape("render (escaped)", function(test){
 tape("render (unescaped)", function(test){
 
   var view = cornea.create({
-        data : {
-          "foo" : "<i></i>"
+        getInitialData : function(){
+          return {
+            "foo" : "<i></i>"
+          }
         },
         template : function(){
           return [
@@ -79,14 +87,17 @@ tape("render (unescaped)", function(test){
       })
     , el
 
-  view.render()
-  el = view.element.querySelector(".test")
+  view.render(function(){
+    el = view.element.querySelector(".test")
 
-  test.equal(el.innerHTML, "<i></i>")
-  view.update("foo", "<b></b>")
-  test.equal(view.element.querySelector(".test"), el, "same element")
-  test.equal(el.innerHTML, "<b></b>")
-  test.end()
+    test.equal(el.innerHTML, "<i></i>")
+    view.update({
+      foo : "<b></b>"
+    })
+    test.equal(view.element.querySelector(".test"), el, "same element")
+    test.equal(el.innerHTML, "<b></b>")
+    test.end()
+  })
 
 })
 
@@ -94,8 +105,10 @@ tape("render (unescaped)", function(test){
 tape("render (value attribute)", function(test){
 
   var view = cornea.create({
-        data : {
-          "foo" : "name"
+        getInitialData : function(){
+          return {
+            "foo" : "name"
+          }
         },
         template : function(){
           var input = document.createElement("input")
@@ -107,14 +120,17 @@ tape("render (value attribute)", function(test){
       })
     , el
 
-  view.render()
-  el = view.element.querySelector("input")
+  view.render(function(){
+    el = view.element.querySelector("input")
 
-  test.equal(el.value, "yo name")
-  view.update("foo", "foo")
-  test.equal(view.element.querySelector("input"), el, "same element")
-  test.equal(el.value, "yo foo")
-  test.end()
+    test.equal(el.value, "yo name")
+    view.update({
+      "foo": "foo"
+    })
+    test.equal(view.element.querySelector("input"), el, "same element")
+    test.equal(el.value, "yo foo")
+    test.end()
+  })
 
 })
 
@@ -123,18 +139,21 @@ tape("render (no template)", function(test){
 
   var view = cornea.create({})
 
-  view.render()
-  test.equal(view.element.innerHTML, "")
-  test.end()
+  view.render(function(){
+    test.equal(view.element.innerHTML, "")
+    test.end()
+  })
 
 })
 
 tape("update loop", function(test){
 
   var view = cornea.create({
-        data : {
-          "bar" : "name",
-          "foo" : "name"
+        getInitialData : function(){
+          return {
+            "bar" : "name",
+            "foo" : "name"
+          }
         },
         template : function(){
           var input = document.createElement("input")
@@ -146,14 +165,20 @@ tape("update loop", function(test){
       })
     , el
 
-  view.render()
-  el = view.element.querySelector("input")
+  view.render(function(){
+    el = view.element.querySelector("input")
 
-  test.equal(el.value, "yo name")
-  view.update("bar", "foo")
-  view.update("foo", "foo")
-  test.equal(view.element.querySelector("input"), el, "same element")
-  test.equal(el.value, "yo foo")
-  test.end()
+    test.equal(el.value, "yo name")
+    view.update({
+      bar : "foo",
+      foo : "foo"
+    })
+    test.equal(view.element.querySelector("input"), el, "same element")
+    test.equal(el.value, "yo foo")
+  })
+  .then(function(){
+    test.pass("returns a promise")
+    test.end()
+  })
 
 })

--- a/test/render.js
+++ b/test/render.js
@@ -1,19 +1,19 @@
 var tape = require("tape")
-  , cornea = require("../")
+var cornea = require("../")
 
 tape("render", function(test){
 
   var view = cornea.create({
-        template : function(){
-          return [
-            "<div>",
-            this.binding("foo").toString({
-              nodeName : "span"
-            }),
-            "</div>"
-          ].join("")
-        }
-      })
+    template : function(){
+      return [
+        "<div>",
+        this.binding("foo").toString({
+          nodeName : "span"
+        }),
+        "</div>"
+      ].join("")
+    }
+  })
 
   view.render(function(){
     test.equal(view.bindings.length, 1)
@@ -30,24 +30,24 @@ tape("render", function(test){
 tape("render (escaped)", function(test){
 
   var view = cornea.create({
-        getInitialData : function(){
-          return {
-            "foo" : "<div>"
-          }
-        },
-        template : function(){
-          return [
-            "<div>",
-            this.binding("foo").toString({
-              className : "test",
-              nodeName : "span",
-              escape : true
-            }),
-            "</div>"
-          ].join("")
-        }
-      })
-    , el
+    getInitialData : function(){
+      return {
+        "foo" : "<div>"
+      }
+    },
+    template : function(){
+      return [
+        "<div>",
+        this.binding("foo").toString({
+          className : "test",
+          nodeName : "span",
+          escape : true
+        }),
+        "</div>"
+      ].join("")
+    }
+  })
+  var el
 
   view.render(function(){
     el = view.element.querySelector(".test")
@@ -68,24 +68,24 @@ tape("render (escaped)", function(test){
 tape("render (unescaped)", function(test){
 
   var view = cornea.create({
-        getInitialData : function(){
-          return {
-            "foo" : "<i></i>"
-          }
-        },
-        template : function(){
-          return [
-            "<div>",
-            this.binding("foo").toString({
-              className : "test",
-              nodeName : "span",
-              escape : false
-            }),
-            "</div>"
-          ].join("")
-        }
-      })
-    , el
+    getInitialData : function(){
+      return {
+        "foo" : "<i></i>"
+      }
+    },
+    template : function(){
+      return [
+        "<div>",
+        this.binding("foo").toString({
+          className : "test",
+          nodeName : "span",
+          escape : false
+        }),
+        "</div>"
+      ].join("")
+    }
+  })
+  var el
 
   view.render(function(){
     el = view.element.querySelector(".test")
@@ -105,20 +105,20 @@ tape("render (unescaped)", function(test){
 tape("render (value attribute)", function(test){
 
   var view = cornea.create({
-        getInitialData : function(){
-          return {
-            "foo" : "name"
-          }
-        },
-        template : function(){
-          var input = document.createElement("input")
-          this.binding("foo").bindAttribute(input, "value", {
-            template: "yo #{*}"
-          })
-          return input
-        }
+    getInitialData : function(){
+      return {
+        "foo" : "name"
+      }
+    },
+    template : function(){
+      var input = document.createElement("input")
+      this.binding("foo").bindAttribute(input, "value", {
+        template: "yo #{*}"
       })
-    , el
+      return input
+    }
+  })
+  var el
 
   view.render(function(){
     el = view.element.querySelector("input")
@@ -149,21 +149,21 @@ tape("render (no template)", function(test){
 tape("update loop", function(test){
 
   var view = cornea.create({
-        getInitialData : function(){
-          return {
-            "bar" : "name",
-            "foo" : "name"
-          }
-        },
-        template : function(){
-          var input = document.createElement("input")
-          this.binding("foo").bindAttribute(input, "value", {
-            template: "yo #{*}"
-          })
-          return input
-        }
+    getInitialData : function(){
+      return {
+        "bar" : "name",
+        "foo" : "name"
+      }
+    },
+    template : function(){
+      var input = document.createElement("input")
+      this.binding("foo").bindAttribute(input, "value", {
+        template: "yo #{*}"
       })
-    , el
+      return input
+    }
+  })
+  var el
 
   view.render(function(){
     el = view.element.querySelector("input")

--- a/test/styles.js
+++ b/test/styles.js
@@ -1,14 +1,14 @@
 var tape = require("tape")
-  , styles = require("../styles")
+var styles = require("../styles")
 
 tape("styles", function(test){
 
   var style = styles.create({id:1})
-    , head = document.head || document.getElementsByTagName("head")[0]
-    , rule
-    , rule2
-    , div = document.createElement("div")
-    , element = style.element
+  var head = document.head || document.getElementsByTagName("head")[0]
+  var rule
+  var rule2
+  var div = document.createElement("div")
+  var element = style.element
 
   test.equal(style.element.nodeName, "STYLE", "created stylesheet")
   test.equal(style.element.parentNode, head, "inserted stylesheet")

--- a/test/styles.js
+++ b/test/styles.js
@@ -13,8 +13,12 @@ tape("styles", function(test){
   test.equal(style.element.nodeName, "STYLE", "created stylesheet")
   test.equal(style.element.parentNode, head, "inserted stylesheet")
   rule = style.createRule(".foo")
-  test.equal(rule.selectorText, "[data-cornea-id=\"1\"] .foo", "creates rules")
-  test.equal(style.element.sheet.cssRules[0].selectorText, "[data-cornea-id=\"1\"] .foo", "rule assimilated")
+  var selectorsFoo = {
+    "[data-cornea-id=\"1\"] .foo" : 1,
+    "[data-cornea-id='1'] .foo" : 1
+  }
+  test.equal(selectorsFoo[rule.selectorText], 1, "creates rules")
+  test.equal(selectorsFoo[style.element.sheet.cssRules[0].selectorText], 1, "rule assimilated")
   test.equal(style._selectors[".foo"], 0, "rule stored")
   test.equal(style.getRule(".foo"), rule, "rule fetched")
   test.equal(style.getRule(" .foo   "), rule, "trimmed rule fetched")
@@ -22,8 +26,12 @@ tape("styles", function(test){
     "font-size" : "45px"
   })
   rule2 = style.createRule(".foo, .bar, #foo")
-  test.equal(rule2.selectorText, "[data-cornea-id=\"1\"] .foo, [data-cornea-id=\"1\"] .bar, [data-cornea-id=\"1\"] #foo", "creates rules")
-  test.equal(style.element.sheet.cssRules[1].selectorText, "[data-cornea-id=\"1\"] .foo, [data-cornea-id=\"1\"] .bar, [data-cornea-id=\"1\"] #foo", "rule assimilated")
+  var selectors = {
+    "[data-cornea-id=\"1\"] .foo, [data-cornea-id=\"1\"] .bar, [data-cornea-id=\"1\"] #foo" : 1,
+    "[data-cornea-id='1'] .foo, [data-cornea-id='1'] .bar, [data-cornea-id='1'] #foo" : 1
+  }
+  test.equal(selectors[rule2.selectorText], 1, "creates rules")
+  test.equal(selectors[style.element.sheet.cssRules[1].selectorText], 1, "rule assimilated")
 
   test.doesNotThrow(function(){
     style.setStyle(".baz")

--- a/test/styles.js
+++ b/test/styles.js
@@ -3,50 +3,31 @@ var tape = require("tape")
 
 tape("styles", function(test){
 
-  var style = styles.create()
+  var style = styles.create({id:1})
     , head = document.head || document.getElementsByTagName("head")[0]
     , rule
+    , rule2
     , div = document.createElement("div")
     , element = style.element
 
   test.equal(style.element.nodeName, "STYLE", "created stylesheet")
   test.equal(style.element.parentNode, head, "inserted stylesheet")
   rule = style.createRule(".foo")
-  test.equal(rule.selectorText, ".foo", "creates rules")
-  test.equal(style.element.sheet.cssRules[0].selectorText, ".foo", "rule assimilated")
+  test.equal(rule.selectorText, "[data-cornea-id=\"1\"] .foo", "creates rules")
+  test.equal(style.element.sheet.cssRules[0].selectorText, "[data-cornea-id=\"1\"] .foo", "rule assimilated")
   test.equal(style._selectors[".foo"], 0, "rule stored")
   test.equal(style.getRule(".foo"), rule, "rule fetched")
   test.equal(style.getRule(" .foo   "), rule, "trimmed rule fetched")
   style.setStyle(".foo", {
     "font-size" : "45px"
   })
-  div.className = "foo"
-  document.body.appendChild(div)
-  test.equal(getComputedStyle(div, null).getPropertyValue("font-size"), "45px")
-  test.equal(style.getRule(".bar"), null, "not found")
-
-  style.setStyle(".baz", {
-    "font-size" : "45px"
-  })
-  test.equal(style.getRule(".baz").selectorText, ".baz", "creates rule if not found")
+  rule2 = style.createRule(".foo, .bar, #foo")
+  test.equal(rule2.selectorText, "[data-cornea-id=\"1\"] .foo, [data-cornea-id=\"1\"] .bar, [data-cornea-id=\"1\"] #foo", "creates rules")
+  test.equal(style.element.sheet.cssRules[1].selectorText, "[data-cornea-id=\"1\"] .foo, [data-cornea-id=\"1\"] .bar, [data-cornea-id=\"1\"] #foo", "rule assimilated")
 
   test.doesNotThrow(function(){
     style.setStyle(".baz")
   })
-
-  style.setStyle(".foo", {
-    "font-size" : null
-  })
-  test.equal(getComputedStyle(div, null).getPropertyValue("font-size"), "16px", "resets if null as value")
-  style.setStyle(".foo", {
-    "font-size" : "45px"
-  })
-  style.destroy()
-  test.equal(element.parentNode, null)
-  test.equal(style.element, null)
-  test.equal(getComputedStyle(div, null).getPropertyValue("font-size"), "16px", "resets styles when ended")
-  style.create()
-  test.notEqual(style.element, element, "changed element")
   test.end()
 
 })

--- a/test/template.js
+++ b/test/template.js
@@ -1,5 +1,5 @@
 var tape = require("tape")
-  , template = require("../template")
+var template = require("../template")
 
 tape("template", function(test){
 

--- a/test/view.js
+++ b/test/view.js
@@ -1,5 +1,5 @@
 var tape = require("tape")
-  , cornea = require("../")
+var cornea = require("../")
 
 function customEvent(element, type) {
   var evt = document.createEvent('Event')
@@ -21,7 +21,7 @@ tape("events", function(test){
   test.plan(13)
 
   var div = document.createElement("div")
-    , span = document.createElement("span")
+  var span = document.createElement("span")
 
   var view = cornea.create({
     initialize : function(){

--- a/test/view.js
+++ b/test/view.js
@@ -95,23 +95,23 @@ tape("class events", function(test){
   test.plan(3)
   var view = cornea.create()
 
-  view.listen("foo", listener)
+  view.on("foo", listener)
   function listener(value){
     test.equal(value, 1)
   }
-  view.listen("foo", function(value){
+  view.on("foo", function(value){
     test.equal(value, 1)
   })
-  view.listen("bar", function(value){
+  view.on("bar", function(value){
     test.equal(value, 1)
   })
 
-  view.fireSync("foo", 1)
-  view.stopListening("foo", listener)
-  view.fireSync("foo", 1)
-  view.stopListening()
-  view.fireSync("bar", 1)
-  view.fireSync("foo", 1)
+  view.emit("foo", 1)
+  view.off("foo", listener)
+  view.emit("foo", 1)
+  view.off()
+  view.emit("bar", 1)
+  view.emit("foo", 1)
 })
 
 tape("class events", function(test){
@@ -119,13 +119,13 @@ tape("class events", function(test){
   test.plan(1)
   var view = cornea.create()
 
-  view.listen("foo", listener)
+  view.on("foo", listener)
   function listener(value){
     test.equal(value, 1)
-    view.stopListening()
-    view.fire("foo", 2)
+    view.off()
+    view.emit("foo", 2)
   }
-  view.fire("foo", 1)
+  view.emit("foo", 1)
 })
 
 

--- a/test/view.js
+++ b/test/view.js
@@ -153,10 +153,10 @@ tape("styles", function(test){
   div.id = "stylesTest"
   document.body.appendChild(div)
   var view = cornea.create({element:"#stylesTest"})
-  view.setStyle("#stylesTest", {
+  view.setStyle("", {
     "font-size" : "60px"
   })
-  view.setStyle("#stylesTest", {
+  view.setStyle("", {
     "font-size" : "40px"
   })
   test.equal(getComputedStyle(div, null).getPropertyValue("font-size"), "40px")

--- a/utils/extend.js
+++ b/utils/extend.js
@@ -1,5 +1,7 @@
 module.exports = function(object, source){
-  if(!source) return
+  if(!source) {
+    return
+  }
   Object.keys(source)
     .forEach(function(key){
       object[key] = source[key]


### PR DESCRIPTION
# cornea 1.0.0
- adapts to bloody-events v1.0.0 (listen → on, stopListening → off, fire → emit)
- hooks events
  - create
  - destroy
  - beforeRender
  - afterRender
  - beforeUpdate
  - afterUpdate
  - styleChange
- scoped styles
- getInitialData (react style)
  - sync getInitialData : `function(){return {foo:"bar"}}`
  - async getInitialData : `function(cb){ request.get("api/foo").then(cb)}`
- update({key:value, key2:value2}) instead of update(key, value)
- async render, returning a promise
- default binding tag is now a `span`
